### PR TITLE
!FIX: 로그인 상태에 따른 라우팅 변경

### DIFF
--- a/backend/src/user/service/user.service.ts
+++ b/backend/src/user/service/user.service.ts
@@ -175,7 +175,7 @@ export class UserService {
   async createUser(data: user42Dto): Promise<User> {
     try {
       const user = await this.userRepository.create({
-        username: null,
+        username: '',
         username42: data.username,
       });
       await this.userRepository.save(user);

--- a/frontend/pages/auth/login/otp.tsx
+++ b/frontend/pages/auth/login/otp.tsx
@@ -8,15 +8,6 @@ import OtpWindow from '@/components/OtpWindow';
 import { SERVER_URL } from '@/utils/variables';
 import { useRouter } from 'next/router';
 
-const styles = {
-  MainText: {
-    fontSize: '140px',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexDir: 'column',
-  } as React.CSSProperties,
-};
-
 export default function OtpPage() {
   let otpStatus: boolean;
   let authStr: string;
@@ -42,7 +33,7 @@ export default function OtpPage() {
       .then((response) => response.json())
       .then((json) => {
         if ('status' in json) {
-          router.push('/auth/basic/id');
+          router.push('/');
         } else {
           setQrCodeSrc(json.qrcode);
         }

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -6,27 +6,31 @@ import { Spacer, Text, VStack } from '@chakra-ui/react';
 import BasicLayout from '@/layouts/BasicLayout';
 import { SERVER_URL } from '@/utils/variables';
 import { useRouter } from 'next/router';
-import { customFetch } from '@/utils/customFetch';
 import { userStore } from '@/stores/userStore';
-import { UserProps } from '@/interfaces/UserProps';
 
 export default function LandingPage() {
   const router = useRouter();
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
   const [isLogin, setIsLogin] = useState<boolean>(false);
+  const [isFirstLogin, setIsFirstLogin] = useState<boolean>(false);
 
   const goToLogin = () => {
     router.push(`${SERVER_URL}/auth`);
   };
 
-  const { fetchMe } = userStore();
+  const { me, fetchMe } = userStore();
 
   useEffect(() => {
     async function fetchData() {
       try {
         await fetchMe();
+        if (me.name === '') {
+          console.log(me.name);
+          setIsFirstLogin(true);
+        }
         setIsLogin(true);
       } catch (e) {
+        console.log(e);
         setIsLogin(false);
       } finally {
         setIsLoaded(true);
@@ -39,7 +43,9 @@ export default function LandingPage() {
     if (!isLoaded) {
       return;
     }
-    if (isLogin) {
+    if (isFirstLogin) {
+      router.push('/auth/basic/id');
+    } else if (isLogin) {
       router.push('/home');
     }
   }, [isLoaded]);

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -13,8 +13,20 @@ export default function Header() {
   const { me, fetchMe, useOtp, fetchUseOtp, toggleUseOtp } = userStore();
   const router = useRouter();
 
-  useEffect(() => fetchMe, []);
-  useEffect(() => fetchUseOtp, []);
+  useEffect(() => {
+    try {
+      fetchMe();
+    } catch (e) {
+      console.log(e);
+    }
+  }, []);
+  useEffect(() => {
+    try {
+      fetchUseOtp();
+    } catch (e) {
+      console.log(e);
+    }
+  }, []);
 
   function logout() {
     removeCookie('accessToken');

--- a/frontend/src/components/OtpWindow.tsx
+++ b/frontend/src/components/OtpWindow.tsx
@@ -32,7 +32,7 @@ export default function OtpWindow({ src }: OtpWindowProps) {
       const json = await customFetch('POST', '/auth/login/otp', { code });
       removeCookie('accessToken');
       setCookie('accessToken', json.token);
-      router.push('/auth/basic/id');
+      router.push('/');
     } catch (e) {
       console.log(e);
       setBgColor(false);

--- a/frontend/src/stores/userStore.ts
+++ b/frontend/src/stores/userStore.ts
@@ -22,7 +22,7 @@ interface userStoreProps {
 
 export const userStore = create<userStoreProps>((set, get) => ({
   me: {
-    name: '',
+    name: ' ', // FIXME: name=''은 첫 로그인인지(이름 정하는 페이지로 라우팅해야 하는지) 구분하는데 사용되므로 초기화는 다른 이름으로 해야함...
     imgUrl: '',
     status: UserStatus.offline,
     rating: 0,


### PR DESCRIPTION
otpOn이면 qr 페이지까지 인증, otpOff이면 일단 42까지 인증 완료
---
이 다음에는 반드시 / 로 라우팅됩니다.
여기서 비로그인 상태이면 가만히(시작 페이지),
첫 로그인 상태이면, /auth/basic/id
이미 이름까지 지정한 상태이면, /home 
으로 라우팅합니다. 

BE username의 기본값은 null이 되어서는 안됩니다. 
FE에서는 typescript를 사용하고 있어 null이면 타입 자체를 다르게 설정해야 해서 복잡해집니다. 
따라서 ''로 수정하였습니다. 