### PR TITLE
feat: DM 전 상태확인 로직 추가

### DIFF
--- a/frontend/src/components/CustomAlert.tsx
+++ b/frontend/src/components/CustomAlert.tsx
@@ -19,16 +19,19 @@ import {
 } from '@chakra-ui/react';
 
 interface AlertProps {
-  status: string;
+  status: String;
   title: string;
   msg: string;
+  onOpen?: () => void;
+  onClose?: () => void;
+  isOpen?: boolean;
 }
 /*
 status  는 error success warning info  중 하나
 
 */
-export default function CustomAlert({ status, title, msg }: AlertProps) {
-  const { isOpen, onClose, onOpen } = useDisclosure({ defaultIsOpen: true });
+export default function CustomAlert({ status, title, msg, onOpen, onClose, isOpen }: AlertProps) {
+  // const { isOpen, onClose, onOpen } = useDisclosure({ defaultIsOpen: true });
 
   return (
     <Alert status={status}>


### PR DESCRIPTION
DM 보내기 전에 USERITEM 마다 마운트시/클릭시 상태를 갱신하여
서로 친구인지확인하고 친구가 아니거나 접속중이 아니면 alert를 띄웁니다.

그러나 sidebar에 표시되는 유저들의 status가 잘 받아와지지 않는 경우가 있어서 연쇄작용으로 제대로 작동하지 않을 경우가 있습니다.